### PR TITLE
Fix de erros de digitação nos imports dos arquivos, acusados pelo meu…

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import { validateRequest } from './validators/validateRequest';
 import { validateToken } from './validators/validateToken';
 import AuthController from './controllers/AuthController';
-import CampaignController from './controllers/CampaignController';
+import CampaignController from './controllers/campaignController';
 import { postLoginValidator } from './validators/postLoginValidator';
 import { postUserValidator } from './validators/postUserValidator';
 import { postCampaignValidator } from './validators/postCampaignValidator';

--- a/api/src/controllers/AuthController.ts
+++ b/api/src/controllers/AuthController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-import LoginService from "../services/LoginService";
-import UserService from "../services/UserService";
+import LoginService from "../services/loginService";
+import UserService from "../services/userService";
 
 class AuthController {
     

--- a/api/src/controllers/campaignController.ts
+++ b/api/src/controllers/campaignController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import {Campaign} from '../entity/Campaign';
-import CampaignService from '../services/CampaingService';
+import CampaignService from '../services/campaingService';
 import IPaginationFilter from '../services/interfaces/IPaginationFilter';
 import IListResult from '../services/interfaces/IListResult';
 


### PR DESCRIPTION
… linter do VIM - 24/11/21

    Bom, encontrei alguns pequenos erros nos imports dos arquivos o linter do VIM que é muito implicante, não me deixava rodar o `yarn start ` dentro da pasta da API, depois de corrigir consegui roda tudo enviando email etc... Depois que eu corrigi na minha máquina percebi também que haveria outra maneira de resolver isto que era renomeando os arquivos, mas daí pensei que eles poderiam estar importados em outros lugares no código e poderia acabar dando mais trabalho, enfim.